### PR TITLE
Using dune to build and test, also added Github Action

### DIFF
--- a/.github/workflows/dune.yml
+++ b/.github/workflows/dune.yml
@@ -1,0 +1,34 @@
+name: Dune
+
+on:
+  - pull_request
+  - push
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        ocaml-version:
+          - 4.11.0
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-version }}
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+
+      - run: opam install dune
+
+      - run: opam exec -- dune build
+
+      - run: opam exec -- dune test

--- a/Sorts/dune
+++ b/Sorts/dune
@@ -1,0 +1,2 @@
+(library
+ (name sorts))

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.7)
+(name ocaml-algorithms)

--- a/searches/dune
+++ b/searches/dune
@@ -1,0 +1,2 @@
+(library
+ (name searches))

--- a/test/Sorts/dune
+++ b/test/Sorts/dune
@@ -1,0 +1,3 @@
+(tests
+ (names quicksort_test)
+ (libraries sorts))

--- a/test/Sorts/quicksort_test.ml
+++ b/test/Sorts/quicksort_test.ml
@@ -1,0 +1,5 @@
+open Sorts.Quicksort
+
+let list_to_sort = [13; 2; 3; 14; 17; 4; 1; 5; 16; 12; 9; 10; 15; 8; 7; 11; 18; 19; 6; 20]
+let sorted_list = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15; 16; 17; 18; 19; 20]
+let _ = assert(quicksort list_to_sort = sorted_list)

--- a/test/searches/dune
+++ b/test/searches/dune
@@ -1,0 +1,3 @@
+(tests
+ (names linear_search_test)
+ (libraries searches))

--- a/test/searches/linear_search_test.ml
+++ b/test/searches/linear_search_test.ml
@@ -1,0 +1,3 @@
+open Searches.Linear_search
+
+let _ = assert(linear_search_array 0 [| 1; 2; 3; 0 |] = Some 3)


### PR DESCRIPTION
- added `dune` and `dune-project` files, so that we can now build and test with `dune test`
- added `test` directory, added test files for `quicksort` and `linear_search`

From now on, contributors can build and test their contributions on their local PC as follows. 
First install [`ocaml`](https://ocaml.org/docs/install.html), [`opam`](https://opam.ocaml.org/) and [`dune`](https://opam.ocaml.org/packages/dune/).
Let's say we add a new algorithm `insertion_sort.ml` to the `Sorts` directory.
We can also add `insertion_sort_test.ml` to the `test/Sorts` directory. In this file we can first type: `open Sorts.Insertion_sort` at the top, then type the tests we want.
We need to edit the `test/Sorts/dune` file. Add `insertion_sort_test` to the `names` line:
`(names quicksort_test insertion_sort_test)`
Then we can run `dune build` and `dune test`.

- added Github Action that builds and tests on push and pull request. Using: https://github.com/marketplace/actions/set-up-ocaml

You can see it in action here: https://github.com/spamegg1/OCaml/actions/runs/313616415

I am new to OCaml, dune and Github Actions so any suggestions are appreciated. 
@dmbaturin Please make suggestions! You seem to be more experienced in OCaml and dune.

The testing can probably be improved by using some libraries such as `OUnit` or `ppx_inline_test` or `alcotest`. I'm new to all this so I could not figure it out yet.

The build runs very slow (6/7/12 mins on Ubuntu/Windows/Mac) but that might be because it was 
the first run ever. I'd appreciate any suggestions on how to enable caching to reduce this time.