### PR TITLE
Implemented Insertion Sort

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -5,3 +5,4 @@
 
 ## Sorts
   * [Quicksort](https://github.com/TheAlgorithms/OCaml/blob/master/Sorts/quicksort.ml)
+  * [Insertion Sort](https://github.com/TheAlgorithms/OCaml/blob/master/Sorts/insertionsort.ml)

--- a/Sorts/insertionsort.ml
+++ b/Sorts/insertionsort.ml
@@ -1,12 +1,19 @@
 (* Insertion Sort
  * https://en.wikipedia.org/wiki/Insertion_sort
  *)
- let rec insert s h =
-  match s with
+ 
+(* Compares h to be sorted with sorted hd and tail. Terminates when 
+ * h is smaller than an element in the list or if it reaches the end.
+ *)
+ let rec insert lst h =
+  match lst with
     | hd::tail -> if hd > h then h::hd::tail else hd::(insert tail h)
     | _ -> [h]
 
-
+(*Effectively a supplementary recurser for insert. Works similarly to the for
+* loop in standard insertion sort. Not as intuitive to look at, but try tracing
+* it out.
+*)
 let rec insertion_sort (lst : int list) : int list = match lst with
   | [] -> []
   | hd::tail -> insert (insertion_sort tail) hd

--- a/Sorts/insertionsort.ml
+++ b/Sorts/insertionsort.ml
@@ -1,0 +1,30 @@
+(* Insertion Sort
+ * https://en.wikipedia.org/wiki/Insertion_sort
+ *)
+ let rec insert s h =
+  match s with
+    | hd::tail -> if hd > h then h::hd::tail else hd::(insert tail h)
+    | _ -> [h]
+
+
+let rec insertion_sort (lst : int list) : int list = match lst with
+  | [] -> []
+  | hd::tail -> insert (insertion_sort tail) hd
+
+ (* testing the insertion sort function *)
+let main () =
+  let list_to_sort =
+      [13; 2; 3; 14; 17; 4; 1; 5; 16; 12; 9; 10; 15; 8; 7; 11; 18; 19; 6; 20]
+  in
+
+  print_string "Unsorted: ";
+  List.iter (Printf.printf "%d ") list_to_sort;
+  print_newline ();
+
+  print_string "  Sorted: ";
+  List.iter (Printf.printf "%d ") (insertion_sort list_to_sort);
+  print_newline ()
+
+
+(* this can be run with: ocaml Sorts/insertionsort.ml on the command line *)
+let _ = main ()


### PR DESCRIPTION
Implemented Insertion Sort in OCaml with documentation and main example function. Utilizes same unsorted list and output style as existing quicksort.ml for consistency.

- Adds insertionsort.ml to the Sorts directory
- Adds an entry to DIRECTORY.md